### PR TITLE
fix: add app name to sentry scope

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -13,33 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     # Job steps
     steps:
-      - name: Checkout
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: "Retrieve NPM Token"
-        id: vault
-        uses: hashicorp/vault-action@v2.4.3
-        with:
-          url: ${{ secrets.VAULT_URL }}
-          role: ${{ github.event.repository.name }}-github-action
-          method: jwt
-          path: github-actions
-          exportEnv: false
-          secrets: |
-            secret/data/github/github_packages_read GITHUB_PACKAGES_READ_TOKEN | GITHUB_PACKAGES_READ_TOKEN
-            
-      - name: "Create GH .npmrc"
-        shell: bash
-        run: |
-          echo -e "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}\n@contentful:registry=https://npm.pkg.github.com\nalways-auth=true" > ~/.npmrc
-        env:
-          GITHUB_TOKEN: ${{ steps.vault.outputs.GITHUB_PACKAGES_READ_TOKEN }}
       - name: Install dependencies
         run: npm install
-        env:
-          GITHUB_TOKEN: ${{ steps.vault.outputs.GITHUB_PACKAGES_READ_TOKEN }}
         # 👇 Adds Chromatic as a step in the workflow
       - name: Publish to Chromatic
         uses: chromaui/action@v1

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ Option 1: Link the package using the global node module namespace
 npm link 
 ```
 
+and within the test application run 
+
+```sh 
+npm link @contentful/integration-frontend-toolkit
+```
+
 Option 2: Use npm pack to create a tgz file locally that mimics a fully packed library structure
 
 ```sh 
@@ -45,7 +51,7 @@ npm build
 npm pack --pack-destination ~
 ```
 
-import the packed file, i.e "file:~/integration-frontend-toolkit-0.0.0.tgz", into another library for testing
+import the packed file, i.e "file:~/contentful-integration-frontend-toolkit-0.0.0-semantic-release.tgz", into another library for testing
 
 and within the testing library run:
 

--- a/src/sdks/sentry/sentryMarketplaceAppsSDK.spec.ts
+++ b/src/sdks/sentry/sentryMarketplaceAppsSDK.spec.ts
@@ -27,7 +27,7 @@ describe('sentryMarketplaceAppsSDK', () => {
     const getCurrentScopeSpy = jest.spyOn(Sentry, 'getCurrentScope');
     const sdkIds = { user: 1 } as unknown as KnownAppSDK['ids'];
     const sdkLocations = { is: () => 'SIDEBAR' } as unknown as KnownAppSDK['location'];
-    sentryMarketplaceAppsSDK.setContentfulSentryContext(sdkIds, sdkLocations);
+    sentryMarketplaceAppsSDK.setContentfulSentryContext(sdkIds, sdkLocations, 'appName');
 
     expect(getCurrentScopeSpy).toHaveBeenCalled();
   });

--- a/src/sdks/sentry/sentryMarketplaceAppsSDK.ts
+++ b/src/sdks/sentry/sentryMarketplaceAppsSDK.ts
@@ -42,7 +42,7 @@ const setContentfulSentryContext = (
 ) => {
   const scope = Sentry.getCurrentScope();
   if (sdkIds.user) scope.setUser({ id: sdkIds.user });
-  if (appName) scope.setTag('contentfulAppName', appName);
+  if (appName) scope.setTag('X-Contentful-App-Name', appName);
   for (const [key, value] of Object.entries(consolidateContentfulAppInfo(sdkIds, sdkLocation))) {
     if (value) scope.setTag(`X-Contentful-${upperFirst(key)}`, value);
   }

--- a/src/sdks/sentry/sentryMarketplaceAppsSDK.ts
+++ b/src/sdks/sentry/sentryMarketplaceAppsSDK.ts
@@ -7,7 +7,8 @@ interface SentryMarketplaceAppSdk {
   init: (configOptions?: Sentry.BrowserOptions) => void;
   setContentfulSentryContext: (
     sdkIds: KnownAppSDK['ids'],
-    sdkLocation: KnownAppSDK['location']
+    sdkLocation: KnownAppSDK['location'],
+    appName?: string
   ) => void;
   client: typeof Sentry;
 }
@@ -30,15 +31,18 @@ const init = (configOptions?: Sentry.BrowserOptions) =>
 /**
  * Method to add Contentful specific details to the Sentry scope
  * @param {object} sdkIds - ids associated with app installation
- * @param {object} sdkLocation - locatio associated with app installation
+ * @param {object} sdkLocation - location associated with app installation
+ * @param {string} appName - name of app where sentry is initialized
  */
 
 const setContentfulSentryContext = (
   sdkIds: KnownAppSDK['ids'],
-  sdkLocation: KnownAppSDK['location']
+  sdkLocation: KnownAppSDK['location'],
+  appName?: string
 ) => {
   const scope = Sentry.getCurrentScope();
   if (sdkIds.user) scope.setUser({ id: sdkIds.user });
+  if (appName) scope.setTag('contentfulAppName', appName);
   for (const [key, value] of Object.entries(consolidateContentfulAppInfo(sdkIds, sdkLocation))) {
     if (value) scope.setTag(`X-Contentful-${upperFirst(key)}`, value);
   }


### PR DESCRIPTION
## Purpose

This PR adds another argument to the Sentry SDK, of `appName` so that we can easily filter and understand the Sentry errors by the `X-Contentful-App-Name` tag. Open to ideas on naming here! 

Additionally, I removed changes added to the Chromatic workflow as those are antiquated per the fixes by MechaGodzilla. 
