### PR TITLE
fix: move segment from a devDep to a dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@contentful/f36-components": "^4.35.0",
         "@contentful/f36-tokens": "^4.0.1",
         "@emotion/css": "^11.10.6",
+        "@segment/analytics-next": "^1.66.0",
         "@sentry/react": "^7.91.0",
         "chart.js": "^4.4.1",
         "lodash": "^4.17.21",
@@ -19,7 +20,6 @@
         "usehooks-ts": "^2.9.1"
       },
       "devDependencies": {
-        "@segment/analytics-next": "^1.64.0",
         "@storybook/addon-a11y": "^7.0.4",
         "@storybook/addon-essentials": "^7.0.2",
         "@storybook/addon-interactions": "^7.0.2",
@@ -5593,7 +5593,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
       "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -5602,7 +5601,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
       "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
-      "dev": true,
       "dependencies": {
         "@lukeed/csprng": "^1.1.0"
       },
@@ -7115,14 +7113,13 @@
       }
     },
     "node_modules/@segment/analytics-next": {
-      "version": "1.64.0",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-next/-/analytics-next-1.64.0.tgz",
-      "integrity": "sha512-2qlyJ2Vnu6qjtuHZCzMg1ebMlbLXAKCzfHPMsZjSV+6BxpZe8pKjA0OVOKtKPTlKq1/aUw44MsKZ4N0JN+xhbw==",
-      "dev": true,
+      "version": "1.66.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-next/-/analytics-next-1.66.0.tgz",
+      "integrity": "sha512-euCOLXUAAfcd/kI5FkCrOJ+Sp3QuCn3f9/1U5J+rly+lfqczKqw4x7A5aon6X3ncBJjfEP3gt9OZdcmgco18Ow==",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
-        "@segment/analytics-core": "1.4.1",
-        "@segment/analytics-generic-utils": "1.1.1",
+        "@segment/analytics-core": "1.5.0",
+        "@segment/analytics-generic-utils": "1.2.0",
         "@segment/analytics.js-video-plugins": "^0.2.1",
         "@segment/facade": "^3.4.9",
         "@segment/tsub": "^2.0.0",
@@ -7132,6 +7129,25 @@
         "spark-md5": "^3.0.1",
         "tslib": "^2.4.1",
         "unfetch": "^4.1.0"
+      }
+    },
+    "node_modules/@segment/analytics-next/node_modules/@segment/analytics-core": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.5.0.tgz",
+      "integrity": "sha512-xFM9sS4ltRWDnNE6bD/bwLAGGBI1Doidf35J6ePyuOfecZ7c0sADtk9xR1QD98CDDFVaQcrfV/O1l4rBZvCm4A==",
+      "dependencies": {
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-generic-utils": "1.2.0",
+        "dset": "^3.1.2",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@segment/analytics-next/node_modules/@segment/analytics-generic-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.2.0.tgz",
+      "integrity": "sha512-DfnW6mW3YQOLlDQQdR89k4EqfHb0g/3XvBXkovH1FstUN93eL1kfW9CsDcVQyH3bAC5ZsFyjA/o/1Q2j0QeoWw==",
+      "dependencies": {
+        "tslib": "^2.4.1"
       }
     },
     "node_modules/@segment/analytics-node": {
@@ -7179,7 +7195,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@segment/analytics.js-video-plugins/-/analytics.js-video-plugins-0.2.1.tgz",
       "integrity": "sha512-lZwCyEXT4aaHBLNK433okEKdxGAuyrVmop4BpQqQSJuRz0DglPZgd9B/XjiiWs1UyOankg2aNYMN3VcS8t4eSQ==",
-      "dev": true,
       "dependencies": {
         "unfetch": "^3.1.1"
       }
@@ -7187,14 +7202,12 @@
     "node_modules/@segment/analytics.js-video-plugins/node_modules/unfetch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-3.1.2.tgz",
-      "integrity": "sha512-L0qrK7ZeAudGiKYw6nzFjnJ2D5WHblUBwmHIqtPS6oKUd+Hcpk7/hKsSmcHsTlpd1TbTNsiRBUKRq3bHLNIqIw==",
-      "dev": true
+      "integrity": "sha512-L0qrK7ZeAudGiKYw6nzFjnJ2D5WHblUBwmHIqtPS6oKUd+Hcpk7/hKsSmcHsTlpd1TbTNsiRBUKRq3bHLNIqIw=="
     },
     "node_modules/@segment/facade": {
       "version": "3.4.10",
       "resolved": "https://registry.npmjs.org/@segment/facade/-/facade-3.4.10.tgz",
       "integrity": "sha512-xVQBbB/lNvk/u8+ey0kC/+g8pT3l0gCT8O2y9Z+StMMn3KAFAQ9w8xfgef67tJybktOKKU7pQGRPolRM1i1pdA==",
-      "dev": true,
       "dependencies": {
         "@segment/isodate-traverse": "^1.1.1",
         "inherits": "^2.0.4",
@@ -7205,14 +7218,12 @@
     "node_modules/@segment/isodate": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@segment/isodate/-/isodate-1.0.3.tgz",
-      "integrity": "sha512-BtanDuvJqnACFkeeYje7pWULVv8RgZaqKHWwGFnL/g/TH/CcZjkIVTfGDp/MAxmilYHUkrX70SqwnYSTNEaN7A==",
-      "dev": true
+      "integrity": "sha512-BtanDuvJqnACFkeeYje7pWULVv8RgZaqKHWwGFnL/g/TH/CcZjkIVTfGDp/MAxmilYHUkrX70SqwnYSTNEaN7A=="
     },
     "node_modules/@segment/isodate-traverse": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@segment/isodate-traverse/-/isodate-traverse-1.1.1.tgz",
       "integrity": "sha512-+G6e1SgAUkcq0EDMi+SRLfT48TNlLPF3QnSgFGVs0V9F3o3fq/woQ2rHFlW20W0yy5NnCUH0QGU3Am2rZy/E3w==",
-      "dev": true,
       "dependencies": {
         "@segment/isodate": "^1.0.3"
       }
@@ -7221,7 +7232,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@segment/tsub/-/tsub-2.0.0.tgz",
       "integrity": "sha512-NzkBK8GwPsyQ74AceLjENbUoaFrObnzEKOX4ko2wZDuIyK+DnDm3B//8xZYI2LCKt+wUD55l6ygfjCoVs8RMWw==",
-      "dev": true,
       "dependencies": {
         "@stdlib/math-base-special-ldexp": "^0.0.5",
         "dlv": "^1.1.3",
@@ -7790,7 +7800,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@stdlib/array-float32/-/array-float32-0.0.6.tgz",
       "integrity": "sha512-QgKT5UaE92Rv7cxfn7wBKZAlwFFHPla8eXsMFsTGt5BiL4yUy36lwinPUh4hzybZ11rw1vifS3VAPuk6JP413Q==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -7818,7 +7827,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@stdlib/array-float64/-/array-float64-0.0.6.tgz",
       "integrity": "sha512-oE8y4a84LyBF1goX5//sU1mOjet8gLI0/6wucZcjg+j/yMmNV1xFu84Az9GOGmFSE6Ze6lirGOhfBeEWNNNaJg==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -7846,7 +7854,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@stdlib/array-uint16/-/array-uint16-0.0.6.tgz",
       "integrity": "sha512-/A8Tr0CqJ4XScIDRYQawosko8ha1Uy+50wsTgJhjUtXDpPRp7aUjmxvYkbe7Rm+ImYYbDQVix/uCiPAFQ8ed4Q==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -7874,7 +7881,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@stdlib/array-uint32/-/array-uint32-0.0.6.tgz",
       "integrity": "sha512-2hFPK1Fg7obYPZWlGDjW9keiIB6lXaM9dKmJubg/ergLQCsJQJZpYsG6mMAfTJi4NT1UF4jTmgvyKD+yf0D9cA==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -7902,7 +7908,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@stdlib/array-uint8/-/array-uint8-0.0.7.tgz",
       "integrity": "sha512-qYJQQfGKIcky6TzHFIGczZYTuVlut7oO+V8qUBs7BJC9TwikVnnOmb3hY3jToY4xaoi5p9OvgdJKPInhyIhzFg==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -7930,7 +7935,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/assert-has-float32array-support/-/assert-has-float32array-support-0.0.8.tgz",
       "integrity": "sha512-Yrg7K6rBqwCzDWZ5bN0VWLS5dNUWcoSfUeU49vTERdUmZID06J069CDc07UUl8vfQWhFgBWGocH3rrpKm1hi9w==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -7964,7 +7968,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/assert-has-float64array-support/-/assert-has-float64array-support-0.0.8.tgz",
       "integrity": "sha512-UVQcoeWqgMw9b8PnAmm/sgzFnuWkZcNhJoi7xyMjbiDV/SP1qLCrvi06mq86cqS3QOCma1fEayJdwgteoXyyuw==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -7997,7 +8000,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/assert-has-node-buffer-support/-/assert-has-node-buffer-support-0.0.8.tgz",
       "integrity": "sha512-fgI+hW4Yg4ciiv4xVKH+1rzdV7e5+6UKgMnFbc1XDXHcxLub3vOr8+H6eDECdAIfgYNA7X0Dxa/DgvX9dwDTAQ==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8030,7 +8032,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@stdlib/assert-has-own-property/-/assert-has-own-property-0.0.7.tgz",
       "integrity": "sha512-3YHwSWiUqGlTLSwxAWxrqaD1PkgcJniGyotJeIt5X0tSNmSW0/c9RWroCImTUUB3zBkyBJ79MyU9Nf4Qgm59fQ==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8055,7 +8056,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/assert-has-symbol-support/-/assert-has-symbol-support-0.0.8.tgz",
       "integrity": "sha512-PoQ9rk8DgDCuBEkOIzGGQmSnjtcdagnUIviaP5YskB45/TJHXseh4NASWME8FV77WFW9v/Wt1MzKFKMzpDFu4Q==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8087,7 +8087,6 @@
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/@stdlib/assert-has-tostringtag-support/-/assert-has-tostringtag-support-0.0.9.tgz",
       "integrity": "sha512-UTsqdkrnQ7eufuH5BeyWOJL3ska3u5nvDWKqw3onNNZ2mvdgkfoFD7wHutVGzAA2rkTsSJAMBHVwWLsm5SbKgw==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8120,7 +8119,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/assert-has-uint16array-support/-/assert-has-uint16array-support-0.0.8.tgz",
       "integrity": "sha512-vqFDn30YrtzD+BWnVqFhB130g3cUl2w5AdOxhIkRkXCDYAM5v7YwdNMJEON+D4jI8YB4D5pEYjqKweYaCq4nyg==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8154,7 +8152,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/assert-has-uint32array-support/-/assert-has-uint32array-support-0.0.8.tgz",
       "integrity": "sha512-tJtKuiFKwFSQQUfRXEReOVGXtfdo6+xlshSfwwNWXL1WPP2LrceoiUoQk7zMCMT6VdbXgGH92LDjVcPmSbH4Xw==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8188,7 +8185,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/assert-has-uint8array-support/-/assert-has-uint8array-support-0.0.8.tgz",
       "integrity": "sha512-ie4vGTbAS/5Py+LLjoSQi0nwtYBp+WKk20cMYCzilT0rCsBI/oez0RqHrkYYpmt4WaJL4eJqC+/vfQ5NsI7F5w==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8222,7 +8218,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@stdlib/assert-is-array/-/assert-is-array-0.0.7.tgz",
       "integrity": "sha512-/o6KclsGkNcZ5hiROarsD9XUs6xQMb4lTwF6O71UHbKWTtomEF/jD0rxLvlvj0BiCxfKrReddEYd2CnhUyskMA==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8250,7 +8245,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@stdlib/assert-is-big-endian/-/assert-is-big-endian-0.0.7.tgz",
       "integrity": "sha512-BvutsX84F76YxaSIeS5ZQTl536lz+f+P7ew68T1jlFqxBhr4v7JVYFmuf24U040YuK1jwZ2sAq+bPh6T09apwQ==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8284,7 +8278,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/assert-is-boolean/-/assert-is-boolean-0.0.8.tgz",
       "integrity": "sha512-PRCpslMXSYqFMz1Yh4dG2K/WzqxTCtlKbgJQD2cIkAtXux4JbYiXCtepuoV7l4Wv1rm0a1eU8EqNPgnOmWajGw==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8314,7 +8307,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/assert-is-buffer/-/assert-is-buffer-0.0.8.tgz",
       "integrity": "sha512-SYmGwOXkzZVidqUyY1IIx6V6QnSL36v3Lcwj8Rvne/fuW0bU2OomsEBzYCFMvcNgtY71vOvgZ9VfH3OppvV6eA==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8342,7 +8334,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/assert-is-float32array/-/assert-is-float32array-0.0.8.tgz",
       "integrity": "sha512-Phk0Ze7Vj2/WLv5Wy8Oo7poZIDMSTiTrEnc1t4lBn3Svz2vfBXlvCufi/i5d93vc4IgpkdrOEwfry6nldABjNQ==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8370,7 +8361,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/assert-is-float64array/-/assert-is-float64array-0.0.8.tgz",
       "integrity": "sha512-UC0Av36EEYIgqBbCIz1lj9g7qXxL5MqU1UrWun+n91lmxgdJ+Z77fHy75efJbJlXBf6HXhcYXECIsc0u3SzyDQ==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8398,7 +8388,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/assert-is-function/-/assert-is-function-0.0.8.tgz",
       "integrity": "sha512-M55Dt2njp5tnY8oePdbkKBRIypny+LpCMFZhEjJIxjLE4rA6zSlHs1yRMqD4PmW+Wl9WTeEM1GYO4AQHl1HAjA==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8426,7 +8415,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@stdlib/assert-is-little-endian/-/assert-is-little-endian-0.0.7.tgz",
       "integrity": "sha512-SPObC73xXfDXY0dOewXR0LDGN3p18HGzm+4K8azTj6wug0vpRV12eB3hbT28ybzRCa6TAKUjwM/xY7Am5QzIlA==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8460,7 +8448,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@stdlib/assert-is-number/-/assert-is-number-0.0.7.tgz",
       "integrity": "sha512-mNV4boY1cUOmoWWfA2CkdEJfXA6YvhcTvwKC0Fzq+HoFFOuTK/scpTd9HanUyN6AGBlWA8IW+cQ1ZwOT3XMqag==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8491,7 +8478,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/assert-is-object/-/assert-is-object-0.0.8.tgz",
       "integrity": "sha512-ooPfXDp9c7w+GSqD2NBaZ/Du1JRJlctv+Abj2vRJDcDPyrnRTb1jmw+AuPgcW7Ca7op39JTbArI+RVHm/FPK+Q==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8519,7 +8505,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/assert-is-object-like/-/assert-is-object-like-0.0.8.tgz",
       "integrity": "sha512-pe9selDPYAu/lYTFV5Rj4BStepgbzQCr36b/eC8EGSJh6gMgRXgHVv0R+EbdJ69KNkHvKKRjnWj0A/EmCwW+OA==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8548,7 +8533,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@stdlib/assert-is-plain-object/-/assert-is-plain-object-0.0.7.tgz",
       "integrity": "sha512-t/CEq2a083ajAgXgSa5tsH8l3kSoEqKRu1qUwniVLFYL4RGv3615CrpJUDQKVtEX5S/OKww5q0Byu3JidJ4C5w==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8580,7 +8564,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@stdlib/assert-is-regexp/-/assert-is-regexp-0.0.7.tgz",
       "integrity": "sha512-ty5qvLiqkDq6AibHlNJe0ZxDJ9Mg896qolmcHb69mzp64vrsORnPPOTzVapAq0bEUZbXoypeijypLPs9sCGBSQ==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8609,7 +8592,6 @@
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/@stdlib/assert-is-regexp-string/-/assert-is-regexp-string-0.0.9.tgz",
       "integrity": "sha512-FYRJJtH7XwXEf//X6UByUC0Eqd0ZYK5AC8or5g5m5efQrgr2lOaONHyDQ3Scj1A2D6QLIJKZc9XBM4uq5nOPXA==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8646,7 +8628,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/assert-is-string/-/assert-is-string-0.0.8.tgz",
       "integrity": "sha512-Uk+bR4cglGBbY0q7O7HimEJiW/DWnO1tSzr4iAGMxYgf+VM2PMYgI5e0TLy9jOSOzWon3YS39lc63eR3a9KqeQ==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8676,7 +8657,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/assert-is-uint16array/-/assert-is-uint16array-0.0.8.tgz",
       "integrity": "sha512-M+qw7au+qglRXcXHjvoUZVLlGt1mPjuKudrVRto6KL4+tDsP2j+A89NDP3Fz8/XIUD+5jhj+65EOKHSMvDYnng==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8704,7 +8684,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/assert-is-uint32array/-/assert-is-uint32array-0.0.8.tgz",
       "integrity": "sha512-cnZi2DicYcplMnkJ3dBxBVKsRNFjzoGpmG9A6jXq4KH5rFl52SezGAXSVY9o5ZV7bQGaF5JLyCLp6n9Y74hFGg==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8732,7 +8711,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/assert-is-uint8array/-/assert-is-uint8array-0.0.8.tgz",
       "integrity": "sha512-8cqpDQtjnJAuVtRkNAktn45ixq0JHaGJxVsSiK79k7GRggvMI6QsbzO6OvcLnZ/LimD42FmgbLd13Yc2esDmZw==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8760,7 +8738,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@stdlib/assert-tools-array-function/-/assert-tools-array-function-0.0.7.tgz",
       "integrity": "sha512-3lqkaCIBMSJ/IBHHk4NcCnk2NYU52tmwTYbbqhAmv7vim8rZPNmGfj3oWkzrCsyCsyTF7ooD+In2x+qTmUbCtQ==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8788,7 +8765,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@stdlib/buffer-ctor/-/buffer-ctor-0.0.7.tgz",
       "integrity": "sha512-4IyTSGijKUQ8+DYRaKnepf9spvKLZ+nrmZ+JrRcB3FrdTX/l9JDpggcUcC/Fe+A4KIZOnClfxLn6zfIlkCZHNA==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8816,7 +8792,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/buffer-from-string/-/buffer-from-string-0.0.8.tgz",
       "integrity": "sha512-Dws5ZbK2M9l4Bkn/ODHFm3lNZ8tWko+NYXqGS/UH/RIQv3PGp+1tXFUSvjwjDneM6ppjQVExzVedUH1ftABs9A==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8847,7 +8822,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/@stdlib/cli-ctor/-/cli-ctor-0.0.3.tgz",
       "integrity": "sha512-0zCuZnzFyxj66GoF8AyIOhTX5/mgGczFvr6T9h4mXwegMZp8jBC/ZkOGMwmp+ODLBTvlcnnDNpNFkDDyR6/c2g==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8877,7 +8851,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@stdlib/complex-float32/-/complex-float32-0.0.7.tgz",
       "integrity": "sha512-POCtQcBZnPm4IrFmTujSaprR1fcOFr/MRw2Mt7INF4oed6b1nzeG647K+2tk1m4mMrMPiuXCdvwJod4kJ0SXxQ==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8909,7 +8882,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/complex-float64/-/complex-float64-0.0.8.tgz",
       "integrity": "sha512-lUJwsXtGEziOWAqCcnKnZT4fcVoRsl6t6ECaCJX45Z7lAc70yJLiwUieLWS5UXmyoADHuZyUXkxtI4oClfpnaw==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8941,7 +8913,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@stdlib/complex-reim/-/complex-reim-0.0.6.tgz",
       "integrity": "sha512-28WXfPSIFMtHb0YgdatkGS4yxX5sPYea5MiNgqPv3E78+tFcg8JJG52NQ/MviWP2wsN9aBQAoCPeu8kXxSPdzA==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -8972,7 +8943,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@stdlib/complex-reimf/-/complex-reimf-0.0.1.tgz",
       "integrity": "sha512-P9zu05ZW2i68Oppp3oHelP7Tk0D7tGBL0hGl1skJppr2vY9LltuNbeYI3C96tQe/7Enw/5GyAWgxoQI4cWccQA==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9003,7 +8973,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/constants-float64-exponent-bias/-/constants-float64-exponent-bias-0.0.8.tgz",
       "integrity": "sha512-IzBJQw9hYgWCki7VoC/zJxEA76Nmf8hmY+VkOWnJ8IyfgTXClgY8tfDGS1cc4l/hCOEllxGp9FRvVdn24A5tKQ==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9031,7 +9000,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@stdlib/constants-float64-high-word-abs-mask/-/constants-float64-high-word-abs-mask-0.0.1.tgz",
       "integrity": "sha512-1vy8SUyMHFBwqUUVaZFA7r4/E3cMMRKSwsaa/EZ15w7Kmc01W/ZmaaTLevRcIdACcNgK+8i8813c8H7LScXNcQ==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9059,7 +9027,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/constants-float64-high-word-exponent-mask/-/constants-float64-high-word-exponent-mask-0.0.8.tgz",
       "integrity": "sha512-z28/EQERc0VG7N36bqdvtrRWjFc8600PKkwvl/nqx6TpKAzMXNw55BS1xT4C28Sa9Z7uBWeUj3UbIFedbkoyMw==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9087,7 +9054,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@stdlib/constants-float64-high-word-sign-mask/-/constants-float64-high-word-sign-mask-0.0.1.tgz",
       "integrity": "sha512-hmTr5caK1lh1m0eyaQqt2Vt3y+eEdAx57ndbADEbXhxC9qSGd0b4bLSzt/Xp4MYBYdQkHAE/BlkgUiRThswhCg==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9115,7 +9081,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/constants-float64-max-base2-exponent/-/constants-float64-max-base2-exponent-0.0.8.tgz",
       "integrity": "sha512-xBAOtso1eiy27GnTut2difuSdpsGxI8dJhXupw0UukGgvy/3CSsyNm+a1Suz/dhqK4tPOTe5QboIdNMw5IgXKQ==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9143,7 +9108,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/constants-float64-max-base2-exponent-subnormal/-/constants-float64-max-base2-exponent-subnormal-0.0.8.tgz",
       "integrity": "sha512-YGBZykSiXFebznnJfWFDwhho2Q9xhUWOL+X0lZJ4ItfTTo40W6VHAyNYz98tT/gJECFype0seNzzo1nUxCE7jQ==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9171,7 +9135,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/constants-float64-min-base2-exponent-subnormal/-/constants-float64-min-base2-exponent-subnormal-0.0.8.tgz",
       "integrity": "sha512-bt81nBus/91aEqGRQBenEFCyWNsf8uaxn4LN1NjgkvY92S1yVxXFlC65fJHsj9FTqvyZ+uj690/gdMKUDV3NjQ==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9199,7 +9162,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/constants-float64-ninf/-/constants-float64-ninf-0.0.8.tgz",
       "integrity": "sha512-bn/uuzCne35OSLsQZJlNrkvU1/40spGTm22g1+ZI1LL19J8XJi/o4iupIHRXuLSTLFDBqMoJlUNphZlWQ4l8zw==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9228,7 +9190,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/constants-float64-pinf/-/constants-float64-pinf-0.0.8.tgz",
       "integrity": "sha512-I3R4rm2cemoMuiDph07eo5oWZ4ucUtpuK73qBJiJPDQKz8fSjSe4wJBAigq2AmWYdd7yJHsl5NJd8AgC6mP5Qw==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9256,7 +9217,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/constants-float64-smallest-normal/-/constants-float64-smallest-normal-0.0.8.tgz",
       "integrity": "sha512-Qwxpn5NA3RXf+mQcffCWRcsHSPTUQkalsz0+JDpblDszuz2XROcXkOdDr5LKgTAUPIXsjOgZzTsuRONENhsSEg==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9284,7 +9244,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@stdlib/constants-uint16-max/-/constants-uint16-max-0.0.7.tgz",
       "integrity": "sha512-7TPoku7SlskA67mAm7mykIAjeEnkQJemw1cnKZur0mT5W4ryvDR6iFfL9xBiByVnWYq/+ei7DHbOv6/2b2jizw==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9309,7 +9268,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@stdlib/constants-uint32-max/-/constants-uint32-max-0.0.7.tgz",
       "integrity": "sha512-8+NK0ewqc1vnEZNqzwFJgFSy3S543Eft7i8WyW/ygkofiqEiLAsujvYMHzPAB8/3D+PYvjTSe37StSwRwvQ6uw==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9334,7 +9292,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@stdlib/constants-uint8-max/-/constants-uint8-max-0.0.7.tgz",
       "integrity": "sha512-fqV+xds4jgwFxwWu08b8xDuIoW6/D4/1dtEjZ1sXVeWR7nf0pjj1cHERq4kdkYxsvOGu+rjoR3MbjzpFc4fvSw==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9359,7 +9316,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/fs-exists/-/fs-exists-0.0.8.tgz",
       "integrity": "sha512-mZktcCxiLmycCJefm1+jbMTYkmhK6Jk1ShFmUVqJvs+Ps9/2EEQXfPbdEniLoVz4HeHLlcX90JWobUEghOOnAQ==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9393,7 +9349,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/fs-read-file/-/fs-read-file-0.0.8.tgz",
       "integrity": "sha512-pIZID/G91+q7ep4x9ECNC45+JT2j0+jdz/ZQVjCHiEwXCwshZPEvxcPQWb9bXo6coOY+zJyX5TwBIpXBxomWFg==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9425,7 +9380,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/fs-resolve-parent-path/-/fs-resolve-parent-path-0.0.8.tgz",
       "integrity": "sha512-ok1bTWsAziChibQE3u7EoXwbCQUDkFjjRAHSxh7WWE5JEYVJQg1F0o3bbjRr4D/wfYYPWLAt8AFIKBUDmWghpg==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9464,7 +9418,6 @@
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/@stdlib/math-base-assert-is-infinite/-/math-base-assert-is-infinite-0.0.9.tgz",
       "integrity": "sha512-JuPDdmxd+AtPWPHu9uaLvTsnEPaZODZk+zpagziNbDKy8DRiU1cy+t+QEjB5WizZt0A5MkuxDTjZ/8/sG5GaYQ==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9494,7 +9447,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/math-base-assert-is-nan/-/math-base-assert-is-nan-0.0.8.tgz",
       "integrity": "sha512-m+gCVBxLFW8ZdAfdkATetYMvM7sPFoMKboacHjb1pe21jHQqVb+/4bhRSDg6S7HGX7/8/bSzEUm9zuF7vqK5rQ==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9522,7 +9474,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/math-base-napi-binary/-/math-base-napi-binary-0.0.8.tgz",
       "integrity": "sha512-B8d0HBPhfXefbdl/h0h5c+lM2sE+/U7Fb7hY/huVeoQtBtEx0Jbx/qKvPSVxMjmWCKfWlbPpbgKpN5GbFgLiAg==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9554,7 +9505,6 @@
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/@stdlib/math-base-napi-unary/-/math-base-napi-unary-0.0.9.tgz",
       "integrity": "sha512-2WNKhjCygkGMp0RgjaD7wAHJTqPZmuVW7yPOc62Tnz2U+Ad8q/tcOcN+uvq2dtKsAGr1HDMIQxZ/XrrThMePyA==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9586,7 +9536,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@stdlib/math-base-special-abs/-/math-base-special-abs-0.0.6.tgz",
       "integrity": "sha512-FaaMUnYs2qIVN3kI5m/qNlBhDnjszhDOzEhxGEoQWR/k0XnxbCsTyjNesR2DkpiKuoAXAr9ojoDe2qBYdirWoQ==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9616,7 +9565,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@stdlib/math-base-special-copysign/-/math-base-special-copysign-0.0.7.tgz",
       "integrity": "sha512-7Br7oeuVJSBKG8BiSk/AIRFTBd2sbvHdV3HaqRj8tTZHX8BQomZ3Vj4Qsiz3kPyO4d6PpBLBTYlGTkSDlGOZJA==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9650,7 +9598,6 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/@stdlib/math-base-special-ldexp/-/math-base-special-ldexp-0.0.5.tgz",
       "integrity": "sha512-RLRsPpCdcJZMhwb4l4B/FsmGfEPEWAsik6KYUkUSSHb7ok/gZWt8LgVScxGMpJMpl5IV0v9qG4ZINVONKjX5KA==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9690,7 +9637,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@stdlib/number-ctor/-/number-ctor-0.0.7.tgz",
       "integrity": "sha512-kXNwKIfnb10Ro3RTclhAYqbE3DtIXax+qpu0z1/tZpI2vkmTfYDQLno2QJrzJsZZgdeFtXIws+edONN9kM34ow==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9715,7 +9661,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@stdlib/number-float64-base-exponent/-/number-float64-base-exponent-0.0.6.tgz",
       "integrity": "sha512-wLXsG+cvynmapoffmj5hVNDH7BuHIGspBcTCdjPaD+tnqPDIm03qV5Z9YBhDh91BdOCuPZQ8Ovu2WBpX+ySeGg==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9745,7 +9690,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@stdlib/number-float64-base-from-words/-/number-float64-base-from-words-0.0.6.tgz",
       "integrity": "sha512-r0elnekypCN831aw9Gp8+08br8HHAqvqtc5uXaxEh3QYIgBD/QM5qSb3b7WSAQ0ZxJJKdoykupODWWBkWQTijg==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9777,7 +9721,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@stdlib/number-float64-base-get-high-word/-/number-float64-base-get-high-word-0.0.6.tgz",
       "integrity": "sha512-jSFSYkgiG/IzDurbwrDKtWiaZeSEJK8iJIsNtbPG1vOIdQMRyw+t0bf3Kf3vuJu/+bnSTvYZLqpCO6wzT/ve9g==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9809,7 +9752,6 @@
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/@stdlib/number-float64-base-normalize/-/number-float64-base-normalize-0.0.9.tgz",
       "integrity": "sha512-+rm7RQJEj8zHkqYFE2a6DgNQSB5oKE/IydHAajgZl40YB91BoYRYf/ozs5/tTwfy2Fc04+tIpSfFtzDr4ZY19Q==",
-      "dev": true,
       "hasInstallScript": true,
       "os": [
         "aix",
@@ -9844,7 +9786,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@stdlib/number-float64-base-to-float32/-/number-float64-base-to-float32-0.0.7.tgz",
       "integrity": "sha512-PNUSi6+cqfFiu4vgFljUKMFY2O9PxI6+T+vqtIoh8cflf+PjSGj3v4QIlstK9+6qU40eGR5SHZyLTWdzmNqLTQ==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9872,7 +9813,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@stdlib/number-float64-base-to-words/-/number-float64-base-to-words-0.0.7.tgz",
       "integrity": "sha512-7wsYuq+2MGp9rAkTnQ985rah7EJI9TfgHrYSSd4UIu4qIjoYmWIKEhIDgu7/69PfGrls18C3PxKg1pD/v7DQTg==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9907,7 +9847,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@stdlib/os-byte-order/-/os-byte-order-0.0.7.tgz",
       "integrity": "sha512-rRJWjFM9lOSBiIX4zcay7BZsqYBLoE32Oz/Qfim8cv1cN1viS5D4d3DskRJcffw7zXDnG3oZAOw5yZS0FnlyUg==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9942,7 +9881,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@stdlib/os-float-word-order/-/os-float-word-order-0.0.7.tgz",
       "integrity": "sha512-gXIcIZf+ENKP7E41bKflfXmPi+AIfjXW/oU+m8NbP3DQasqHaZa0z5758qvnbO8L1lRJb/MzLOkIY8Bx/0cWEA==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -9976,7 +9914,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/process-cwd/-/process-cwd-0.0.8.tgz",
       "integrity": "sha512-GHINpJgSlKEo9ODDWTHp0/Zc/9C/qL92h5Mc0QlIFBXAoUjy6xT4FB2U16wCNZMG3eVOzt5+SjmCwvGH0Wbg3Q==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -10008,7 +9945,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@stdlib/process-read-stdin/-/process-read-stdin-0.0.7.tgz",
       "integrity": "sha512-nep9QZ5iDGrRtrZM2+pYAvyCiYG4HfO0/9+19BiLJepjgYq4GKeumPAQo22+1xawYDL7Zu62uWzYszaVZcXuyw==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -10041,7 +9977,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@stdlib/regexp-eol/-/regexp-eol-0.0.7.tgz",
       "integrity": "sha512-BTMpRWrmlnf1XCdTxOrb8o6caO2lmu/c80XSyhYCi1DoizVIZnqxOaN5yUJNCr50g28vQ47PpsT3Yo7J3SdlRA==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -10073,7 +10008,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@stdlib/regexp-extended-length-path/-/regexp-extended-length-path-0.0.7.tgz",
       "integrity": "sha512-z6uqzMWq3WPDKbl4MIZJoNA5ZsYLQI9G3j2TIvhU8X2hnhlku8p4mvK9F+QmoVvgPxKliwNnx/DAl7ltutSDKw==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -10101,7 +10035,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@stdlib/regexp-function-name/-/regexp-function-name-0.0.7.tgz",
       "integrity": "sha512-MaiyFUUqkAUpUoz/9F6AMBuMQQfA9ssQfK16PugehLQh4ZtOXV1LhdY8e5Md7SuYl9IrvFVg1gSAVDysrv5ZMg==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -10129,7 +10062,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/regexp-regexp/-/regexp-regexp-0.0.8.tgz",
       "integrity": "sha512-S5PZICPd/XRcn1dncVojxIDzJsHtEleuJHHD7ji3o981uPHR7zI2Iy9a1eV2u7+ABeUswbI1Yuix6fXJfcwV1w==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -10157,7 +10089,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@stdlib/streams-node-stdin/-/streams-node-stdin-0.0.7.tgz",
       "integrity": "sha512-gg4lgrjuoG3V/L29wNs32uADMCqepIcmoOFHJCTAhVe0GtHDLybUVnLljaPfdvmpPZmTvmusPQtIcscbyWvAyg==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -10182,7 +10113,6 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/@stdlib/string-base-format-interpolate/-/string-base-format-interpolate-0.0.4.tgz",
       "integrity": "sha512-8FC8+/ey+P5hf1B50oXpXzRzoAgKI1rikpyKZ98Xmjd5rcbSq3NWYi8TqOF8mUHm9hVZ2CXWoNCtEe2wvMQPMg==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -10207,7 +10137,6 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/@stdlib/string-base-format-tokenize/-/string-base-format-tokenize-0.0.4.tgz",
       "integrity": "sha512-+vMIkheqAhDeT/iF5hIQo95IMkt5IzC68eR3CxW1fhc48NMkKFE2UfN73ET8fmLuOanLo/5pO2E90c2G7PExow==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -10232,7 +10161,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/@stdlib/string-format/-/string-format-0.0.3.tgz",
       "integrity": "sha512-1jiElUQXlI/tTkgRuzJi9jUz/EjrO9kzS8VWHD3g7gdc3ZpxlA5G9JrIiPXGw/qmZTi0H1pXl6KmX+xWQEQJAg==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -10261,7 +10189,6 @@
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/@stdlib/string-lowercase/-/string-lowercase-0.0.9.tgz",
       "integrity": "sha512-tXFFjbhIlDak4jbQyV1DhYiSTO8b1ozS2g/LELnsKUjIXECDKxGFyWYcz10KuyAWmFotHnCJdIm8/blm2CfDIA==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -10297,7 +10224,6 @@
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/@stdlib/string-replace/-/string-replace-0.0.11.tgz",
       "integrity": "sha512-F0MY4f9mRE5MSKpAUfL4HLbJMCbG6iUTtHAWnNeAXIvUX1XYIw/eItkA58R9kNvnr1l5B08bavnjrgTJGIKFFQ==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -10339,7 +10265,6 @@
       "version": "0.0.14",
       "resolved": "https://registry.npmjs.org/@stdlib/types/-/types-0.0.14.tgz",
       "integrity": "sha512-AP3EI9/il/xkwUazcoY+SbjtxHRrheXgSbWZdEGD+rWpEgj6n2i63hp6hTOpAB5NipE0tJwinQlDGOuQ1lCaCw==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -10364,7 +10289,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/utils-constructor-name/-/utils-constructor-name-0.0.8.tgz",
       "integrity": "sha512-GXpyNZwjN8u3tyYjL2GgGfrsxwvfogUC3gg7L7NRZ1i86B6xmgfnJUYHYOUnSfB+R531ET7NUZlK52GxL7P82Q==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -10394,7 +10318,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/utils-convert-path/-/utils-convert-path-0.0.8.tgz",
       "integrity": "sha512-GNd8uIswrcJCctljMbmjtE4P4oOjhoUIfMvdkqfSrRLRY+ZqPB2xM+yI0MQFfUq/0Rnk/xtESlGSVLz9ZDtXfA==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -10433,7 +10356,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@stdlib/utils-define-nonenumerable-read-only-property/-/utils-define-nonenumerable-read-only-property-0.0.7.tgz",
       "integrity": "sha512-c7dnHDYuS4Xn3XBRWIQBPcROTtP/4lkcFyq0FrQzjXUjimfMgHF7cuFIIob6qUTnU8SOzY9p0ydRR2QJreWE6g==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -10462,7 +10384,6 @@
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/@stdlib/utils-define-property/-/utils-define-property-0.0.9.tgz",
       "integrity": "sha512-pIzVvHJvVfU/Lt45WwUAcodlvSPDDSD4pIPc9WmIYi4vnEBA9U7yHtiNz2aTvfGmBMTaLYTVVFIXwkFp+QotMA==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -10490,7 +10411,6 @@
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/@stdlib/utils-escape-regexp-string/-/utils-escape-regexp-string-0.0.9.tgz",
       "integrity": "sha512-E+9+UDzf2mlMLgb+zYrrPy2FpzbXh189dzBJY6OG+XZqEJAXcjWs7DURO5oGffkG39EG5KXeaQwDXUavcMDCIw==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -10519,7 +10439,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@stdlib/utils-get-prototype-of/-/utils-get-prototype-of-0.0.7.tgz",
       "integrity": "sha512-fCUk9lrBO2ELrq+/OPJws1/hquI4FtwG0SzVRH6UJmJfwb1zoEFnjcwyDAy+HWNVmo3xeRLsrz6XjHrJwer9pg==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -10548,7 +10467,6 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@stdlib/utils-global/-/utils-global-0.0.7.tgz",
       "integrity": "sha512-BBNYBdDUz1X8Lhfw9nnnXczMv9GztzGpQ88J/6hnY7PHJ71av5d41YlijWeM9dhvWjnH9I7HNE3LL7R07yw0kA==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -10576,7 +10494,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/utils-library-manifest/-/utils-library-manifest-0.0.8.tgz",
       "integrity": "sha512-IOQSp8skSRQn9wOyMRUX9Hi0j/P5v5TvD8DJWTqtE8Lhr8kVVluMBjHfvheoeKHxfWAbNHSVpkpFY/Bdh/SHgQ==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -10611,7 +10528,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -10619,14 +10535,12 @@
     "node_modules/@stdlib/utils-library-manifest/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/@stdlib/utils-native-class": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/utils-native-class/-/utils-native-class-0.0.8.tgz",
       "integrity": "sha512-0Zl9me2V9rSrBw/N8o8/9XjmPUy8zEeoMM0sJmH3N6C9StDsYTjXIAMPGzYhMEWaWHvGeYyNteFK2yDOVGtC3w==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -10655,7 +10569,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/utils-next-tick/-/utils-next-tick-0.0.8.tgz",
       "integrity": "sha512-l+hPl7+CgLPxk/gcWOXRxX/lNyfqcFCqhzzV/ZMvFCYLY/wI9lcWO4xTQNMALY2rp+kiV+qiAiO9zcO+hewwUg==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -10680,7 +10593,6 @@
       "version": "0.0.14",
       "resolved": "https://registry.npmjs.org/@stdlib/utils-noop/-/utils-noop-0.0.14.tgz",
       "integrity": "sha512-A5faFEUfszMgd93RCyB+aWb62hQxgP+dZ/l9rIOwNWbIrCYNwSuL4z50lNJuatnwwU4BQ4EjQr+AmBsnvuLcyQ==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -10705,7 +10617,6 @@
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/@stdlib/utils-regexp-from-string/-/utils-regexp-from-string-0.0.9.tgz",
       "integrity": "sha512-3rN0Mcyiarl7V6dXRjFAUMacRwe0/sYX7ThKYurf0mZkMW9tjTP+ygak9xmL9AL0QQZtbrFFwWBrDO+38Vnavw==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -10735,7 +10646,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@stdlib/utils-type-of/-/utils-type-of-0.0.8.tgz",
       "integrity": "sha512-b4xqdy3AnnB7NdmBBpoiI67X4vIRxvirjg3a8BfhM5jPr2k0njby1jAbG9dUxJvgAV6o32S4kjUgfIdjEYpTNQ==",
-      "dev": true,
       "os": [
         "aix",
         "darwin",
@@ -17664,8 +17574,7 @@
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
     },
     "node_modules/dns-equal": {
       "version": "1.0.0",
@@ -17851,7 +17760,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.3.tgz",
       "integrity": "sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -17971,7 +17879,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -17980,7 +17888,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -21216,8 +21124,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -24609,7 +24516,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
       "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -25919,7 +25825,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -26105,7 +26010,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/new-date/-/new-date-1.0.3.tgz",
       "integrity": "sha512-0fsVvQPbo2I18DT2zVHpezmeeNYV2JaJSrseiHLc17GNOxJzUdx5mvSigPu8LtIfZSij5i1wXnXFspEs2CD6hA==",
-      "dev": true,
       "dependencies": {
         "@segment/isodate": "1.0.3"
       }
@@ -26145,7 +26049,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -29605,8 +29508,7 @@
     "node_modules/obj-case": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/obj-case/-/obj-case-0.2.1.tgz",
-      "integrity": "sha512-PquYBBTy+Y6Ob/O2574XHhDtHJlV1cJHMCgW+rDRc9J5hhmRelJB3k5dTK/3cVmFVtzvAKuENeuLpoyTzMzkOg==",
-      "dev": true
+      "integrity": "sha512-PquYBBTy+Y6Ob/O2574XHhDtHJlV1cJHMCgW+rDRc9J5hhmRelJB3k5dTK/3cVmFVtzvAKuENeuLpoyTzMzkOg=="
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -33832,7 +33734,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/sanitize.css": {
       "version": "13.0.0",
@@ -34891,8 +34793,7 @@
     "node_modules/spark-md5": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
-      "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==",
-      "dev": true
+      "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw=="
     },
     "node_modules/spawn-error-forwarder": {
       "version": "1.0.0",
@@ -36397,8 +36298,7 @@
     "node_modules/tiny-hashes": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tiny-hashes/-/tiny-hashes-1.0.1.tgz",
-      "integrity": "sha512-knIN5zj4fl7kW4EBU5sLP20DWUvi/rVouvJezV0UAym2DkQaqm365Nyc8F3QEiOvunNDMxR8UhcXd1d5g+Wg1g==",
-      "dev": true
+      "integrity": "sha512-knIN5zj4fl7kW4EBU5sLP20DWUvi/rVouvJezV0UAym2DkQaqm365Nyc8F3QEiOvunNDMxR8UhcXd1d5g+Wg1g=="
     },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
@@ -36501,8 +36401,7 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/traverse": {
       "version": "0.6.8",
@@ -36957,8 +36856,7 @@
     "node_modules/unfetch": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
-      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==",
-      "dev": true
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -38201,7 +38099,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -38210,8 +38107,7 @@
     "node_modules/whatwg-url/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@contentful/f36-components": "^4.35.0",
     "@contentful/f36-tokens": "^4.0.1",
     "@emotion/css": "^11.10.6",
+    "@segment/analytics-next": "^1.66.0",
     "@sentry/react": "^7.91.0",
     "chart.js": "^4.4.1",
     "lodash": "^4.17.21",
@@ -64,7 +65,6 @@
     ]
   },
   "devDependencies": {
-    "@segment/analytics-next": "^1.64.0",
     "@storybook/addon-a11y": "^7.0.4",
     "@storybook/addon-essentials": "^7.0.2",
     "@storybook/addon-interactions": "^7.0.2",


### PR DESCRIPTION
## Purpose

The purpose of this PR is to move the Segment dependency to the list of main `dependencies` as opposed to where it was in the devDependencies. This dep was not appropriately externalized as a devDep. 

## Description

The following [error](https://app.circleci.com/pipelines/github/contentful/apps/29431/workflows/ce6e9ce6-65a9-4c70-a630-ab4a9115216c/jobs/95920) was occurring in the build of MS teams: 
<img width="1258" alt="Screenshot 2024-03-19 at 9 06 24 AM" src="https://github.com/contentful/integration-frontend-toolkit/assets/58186851/f215f4f5-5327-464e-9782-34873540f67f">

Moving the dependency to the main list that is externalized should solve this issue 🤞 given precedence of all other dependencies utilized such as lodash, Sentry etc. 

## Breaking Changes

No breaking changes

## TO DO

How can we catch this build failure within this repository, preventing it from throwing an error in other repos? The local build works fine even with this issue 🤔 I will create a ticket for this follow-up work.
