### PR TITLE
feat: SearchBar - add an optional prop to disable text input

### DIFF
--- a/src/components/general/SearchBar/SearchBar.tsx
+++ b/src/components/general/SearchBar/SearchBar.tsx
@@ -12,6 +12,7 @@ export interface SearchBarProps {
   onSearch: (searchParams: SearchParams) => void;
   searchTitle?: string;
   placeholder?: string;
+  isDisabled?: boolean;
 }
 
 /**
@@ -22,7 +23,14 @@ export interface SearchBarProps {
  * Filter facets will be used to filter the search results by a specific facet
  */
 const SearchBar = (props: SearchBarProps) => {
-  const { groupFilters, filterFacets, onSearch, searchTitle, placeholder } = props;
+  const {
+    groupFilters,
+    filterFacets,
+    onSearch,
+    searchTitle,
+    placeholder,
+    isDisabled = false,
+  } = props;
 
   const initialState: SearchParams = {
     selectedGroupFilter: !!groupFilters?.length ? groupFilters[0].value : '',
@@ -42,6 +50,7 @@ const SearchBar = (props: SearchBarProps) => {
     <TextInput
       id="search-input"
       type="text"
+      isDisabled={isDisabled}
       value={searchState.searchValue}
       placeholder={placeholder || 'Search'}
       title={searchTitle || 'Search'}

--- a/src/components/general/SearchBar/Searchbar.spec.tsx
+++ b/src/components/general/SearchBar/Searchbar.spec.tsx
@@ -74,4 +74,11 @@ describe('SearchBar', () => {
 
     jest.useRealTimers();
   });
+
+  it('accepts an optional prop of `isDisabled`', async () => {
+    const { getByLabelText } = render(<SearchBar {...defaultProps} isDisabled={true} />);
+    const searchInput = getByLabelText(defaultProps.searchTitle!) as HTMLInputElement;
+
+    expect(searchInput).toBeDisabled();
+  });
 });

--- a/src/components/general/SearchBar/Searchbar.stories.tsx
+++ b/src/components/general/SearchBar/Searchbar.stories.tsx
@@ -32,6 +32,7 @@ Default.args = {
   },
   searchTitle: '',
   placeholder: 'Search Placeholder Text',
+  isDisabled: false,
 };
 
 export default meta;

--- a/src/components/general/SearchBar/index.ts
+++ b/src/components/general/SearchBar/index.ts
@@ -1,1 +1,2 @@
 export { default as SearchBar } from './SearchBar';
+export type { SearchParams } from './SearchBar.types';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,3 +3,4 @@ export { LineChart } from './stacks/analytics/LineChart/index.js';
 export { SearchBar } from './general/SearchBar/index.js';
 export { LocalHostWarning } from './general/LocalHostWarning/index.js';
 export { SearchableList } from './general/SearchableList/index.js';
+export type { SearchParams } from './general/SearchBar/index.js';


### PR DESCRIPTION
## Purpose
Add an optional `isDisabled` prop to `<SearchBar />`
![search-input](https://github.com/contentful/integration-frontend-toolkit/assets/158083968/def6ad0d-5274-4799-a288-974d448693a9)

bonus: expose the `SearchParams` type, so that it doesn't have to be imported from types file.

```
- import type { SearchParams } from '@contentful/integration-frontend-toolkit/components/general/SearchBar/SearchBar.types';
+ import type { SearchParams } from '@contentful/integration-frontend-toolkit/components';
```

## Testing steps
Unit tested and storybook tested.
