### PR TITLE
docs: add golden context files for AI agent navigation [TRANS-13]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,54 @@
+# Agent Guide — @contentful/integration-frontend-toolkit
+
+## What This Repo Does
+A shared React component library and SDK wrapper library for Contentful marketplace app frontends. Provides reusable UI components (search, charts, hyperlinks), a Sentry SDK wrapper pre-configured for marketplace apps, and a Segment analytics context provider.
+
+Currently used by the `microsoft-teams` app in `contentful/apps`.
+
+## Ownership
+`@contentful/team-marketplace` (full, sole owner)
+
+## Structure
+
+```
+src/
+├── components/
+│   ├── general/           # HyperLink, SearchBar, LocalHostWarning, SearchableList
+│   └── stacks/analytics/  # LineChart (Chart.js wrapper)
+├── sdks/
+│   ├── sentry/            # sentryMarketplaceAppsSDK — pre-configured Sentry for marketplace apps
+│   └── segment/           # SegmentMarketplaceProvider — Segment analytics context provider
+└── types/                 # ContentfulNetworkHeaders interface
+```
+
+## Public API
+
+**Components** (import from `@contentful/integration-frontend-toolkit/components`):
+- `HyperLink` — link component
+- `SearchBar` — search input
+- `SearchableList` — searchable list
+- `LocalHostWarning` — dev localhost warning banner
+- `LineChart` — Chart.js line chart wrapper
+
+**SDKs** (import from `@contentful/integration-frontend-toolkit/sdks`):
+- `sentryMarketplaceAppsSDK` — initializes Sentry pre-configured for Contentful marketplace apps
+- `SegmentAnalyticsProvider` — React context provider for Segment tracking
+- `SegmentAnalyticsContext` — context for accessing analytics in child components
+
+## Sharp Edges & Invariants
+
+- **Subpath imports only** — consumers should import from `/components` or `/sdks` subpaths, not the root. The root `index.ts` re-exports everything but subpath imports enable better tree-shaking.
+- **ES modules only** — output is ESM only (no CJS). Consumers must support ES modules.
+- **React and `@contentful/react-apps-toolkit` are peer dependencies** — do not move them to `dependencies`.
+- **Jest via `react-scripts`** — tests use Jest (not Vitest). Do not replace the test runner.
+- **Storybook is required for new components** — every new React component needs a `.stories.tsx` file. Chromatic runs visual regression tests in CI.
+- **Each entity in its own directory** — follow the pattern: `ComponentName/index.ts`, `ComponentName/ComponentName.tsx`, `ComponentName/ComponentName.spec.tsx`, `ComponentName/ComponentName.stories.tsx`.
+- **Publishes to GitHub Packages** — `npm.pkg.github.com`, public access.
+
+## Never / Always
+
+- **Never** add a component without a `.stories.tsx` file — Chromatic will fail.
+- **Never** add a component without a `.spec.tsx` test file.
+- **Never** manually bump the version — semantic-release on `master` handles it.
+- **Always** use lowercase directory and file names — except React component files themselves (PascalCase).
+- **Always** export new entities from the parent `index.ts`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,92 @@
+# Architecture — @contentful/integration-frontend-toolkit
+
+## Overview
+
+A single-package React component and SDK library. Published as ESM to GitHub Packages. Provides UI primitives and pre-configured telemetry SDKs for use in Contentful marketplace app frontends.
+
+## Package Structure
+
+```
+src/
+├── components/           # React UI components
+│   ├── general/
+│   │   ├── HyperLink/
+│   │   ├── SearchBar/
+│   │   ├── LocalHostWarning/
+│   │   └── SearchableList/
+│   └── stacks/analytics/
+│       └── LineChart/    # Chart.js wrapper
+├── sdks/
+│   ├── sentry/
+│   │   └── sentryMarketplaceAppsSDK.ts   # @sentry/react wrapper
+│   └── segment/
+│       ├── SegmentMarketplaceProvider.tsx # Analytics context provider
+│       ├── segmentMarketplaceContext.tsx  # React context
+│       └── typewriter/                   # Typed Segment analytics (generated)
+└── types/
+    └── index.ts          # ContentfulNetworkHeaders
+```
+
+## Subpath Export Map
+
+```json
+{
+  ".": "./index.js",
+  "./components": "./components/index.js",
+  "./sdks": "./sdks/index.js"
+}
+```
+
+Consumers should use subpath imports for tree-shaking. All entities are also re-exported from the root for convenience.
+
+## Build Pipeline
+
+```
+tsc → type checking + .d.ts generation
+Vite → ESM bundle:
+  index.es.js       (root)
+  components/       (subpath)
+  sdks/             (subpath)
+```
+
+`prepublishOnly` runs `npm run build` automatically before publishing.
+
+## Key Dependencies
+
+| Package | Role |
+|---------|------|
+| `@contentful/app-sdk` | App SDK types used in SDK wrappers |
+| `@contentful/f36-components` | Forma 36 UI components (runtime dep) |
+| `@sentry/react` | Sentry React SDK wrapped by `sentryMarketplaceAppsSDK` |
+| `@segment/analytics-next` | Segment analytics client wrapped by `SegmentMarketplaceProvider` |
+| `chart.js` + `react-chartjs-2` | Charting (LineChart component) |
+| `fuse.js` | Fuzzy search (SearchableList, SearchBar) |
+| `@emotion/css` | CSS-in-JS styling |
+| React 16.8+ | Peer dep |
+| `@contentful/react-apps-toolkit` | Peer dep |
+
+## CI / Release
+
+```
+Every push:
+  chromatic.yml → Chromatic visual regression testing → Storybook publish
+
+Every push to master / PRs to master:
+  release-package.yml → npm ci → build → test → semantic-release → publish to GitHub Packages
+```
+
+Semantic-release on `master` branch. Publishes to `npm.pkg.github.com` under `@contentful` scope with public access.
+
+## File Conventions
+
+Every entity follows this structure (enforced by team convention, not tooling):
+
+```
+ComponentName/
+├── index.ts                    # re-export
+├── ComponentName.tsx           # implementation
+├── ComponentName.spec.tsx      # unit + component tests (Jest + Testing Library)
+└── ComponentName.stories.tsx   # Storybook stories (required for CI)
+```
+
+Files: lowercase directories, PascalCase React component files.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,93 @@
+# Contributing to @contentful/integration-frontend-toolkit
+
+## Prerequisites
+
+| Tool | Version |
+|------|---------|
+| Node.js | 19.6.0 (`.nvmrc`) |
+| npm | bundled with Node |
+
+## Setup
+
+```bash
+git clone https://github.com/contentful/integration-frontend-toolkit.git
+cd integration-frontend-toolkit
+npm install
+```
+
+## Running Tests
+
+```bash
+npm test        # interactive watch mode (Jest via react-scripts)
+npm run test:ci # single run (CI mode)
+```
+
+Tests use **Jest + React Testing Library**. Test files are co-located as `ComponentName.spec.tsx` or `*.spec.ts`.
+
+## Storybook
+
+```bash
+npm run storybook    # dev server on port 6006
+npm run build-storybook  # static build
+```
+
+Every new React component **requires** a `.stories.tsx` file. Chromatic runs visual regression tests against Storybook in CI — PRs without stories for new components will fail.
+
+## Building
+
+```bash
+npm run build
+```
+
+Runs TypeScript compilation + Vite build. Output goes to `dist/`. ESM only.
+
+## Linting
+
+```bash
+npm run lint   # ESLint — zero warnings threshold
+```
+
+Prettier and lint-staged run automatically on staged files via Husky pre-commit hook.
+
+## Adding a New Component
+
+1. Create `src/components/general/<ComponentName>/`
+2. Add `<ComponentName>.tsx` (implementation)
+3. Add `<ComponentName>.spec.tsx` (tests — required)
+4. Add `<ComponentName>.stories.tsx` (Storybook — required)
+5. Add `index.ts` re-export
+6. Export from `src/components/index.ts`
+
+Same pattern applies for new SDK wrappers under `src/sdks/`.
+
+## Code Conventions
+
+- **TypeScript** throughout
+- **Conventional Commits** — `feat:`, `fix:`, `chore:`, `docs:`
+- **Lowercase directories**, PascalCase React component files
+- **React + `@contentful/react-apps-toolkit` are peer deps** — do not add them to `dependencies`
+- **ESM output only** — do not configure CJS output in Vite
+
+## Releasing
+
+Releases are automated via semantic-release on `master`. Do not manually bump versions.
+
+## Troubleshooting
+
+**Chromatic visual regression failures in CI**
+A visual change was detected. Review the Chromatic link in the CI output and approve intentional changes.
+
+**`npm link` for local testing**
+```bash
+npm run build
+npm link
+cd ../your-app
+npm link @contentful/integration-frontend-toolkit
+```
+
+**`npm pack` for offline testing**
+```bash
+npm run build
+npm pack   # generates a .tgz
+npm install /path/to/contentful-integration-frontend-toolkit-x.y.z.tgz
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 | Tool | Version |
 |------|---------|
-| Node.js | 19.6.0 (`.nvmrc`) |
+| Node.js | see `.nvmrc` |
 | npm | bundled with Node |
 
 ## Setup


### PR DESCRIPTION
## Summary
- Adds `AGENTS.md`, `ARCHITECTURE.md`, and `CONTRIBUTING.md` to make this repo navigable for AI agents and new engineers without a human guide
- `AGENTS.md` covers the React component library + Sentry/Segment SDK wrapper pattern, Storybook requirement, and Chromatic visual regression testing
- `ARCHITECTURE.md` documents the component/SDK split, package structure, and the Storybook-as-test-harness pattern
- `CONTRIBUTING.md` documents the dev/test/release workflow including the mandatory `.stories.tsx` requirement

## Test plan
- [ ] Verify files render correctly on GitHub
- [ ] Spot-check that repo paths and commands referenced in the docs are accurate

Generated with [Claude Code](https://claude.com/claude-code)